### PR TITLE
fix(package): update @octokit/plugin-rest-endpoint-methods to ^3.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1623,9 +1623,9 @@
       "dev": true
     },
     "@octokit/plugin-rest-endpoint-methods": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-2.4.0.tgz",
-      "integrity": "sha512-EZi/AWhtkdfAYi01obpX0DF7U6b1VRr30QNQ5xSFPITMdLSfhcBqjamE3F+sKcxPbD7eZuMHu3Qkk2V+JGxBDQ==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-3.2.0.tgz",
+      "integrity": "sha512-k+RLsegQn4s0wvAFYuk3R18FVKRg3ktvzIGW6MkmrSiSXBwYfaEsv4CuPysyef0DL+74DRj/X9MLJYlbleUO+Q==",
       "requires": {
         "@octokit/types": "^2.0.1",
         "deprecation": "^2.3.1"
@@ -1665,7 +1665,6 @@
         "@octokit/auth-token": "^2.4.0",
         "@octokit/plugin-paginate-rest": "^1.1.1",
         "@octokit/plugin-request-log": "^1.0.0",
-        "@octokit/plugin-rest-endpoint-methods": "2.4.0",
         "@octokit/request": "^5.2.0",
         "@octokit/request-error": "^1.0.2",
         "atob-lite": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@octokit/auth-action": "^1.2.0",
     "@octokit/core": "^2.1.1",
     "@octokit/plugin-paginate-rest": "^2.0.1",
-    "@octokit/plugin-rest-endpoint-methods": "^2.4.0",
+    "@octokit/plugin-rest-endpoint-methods": "^3.2.0",
     "@octokit/types": "^2.0.2"
   },
   "devDependencies": {


### PR DESCRIPTION
BREAKING CHANGE: All deprecated methods and options have been removed. Upgrade to the latest 1.x.x version, run your tests and address all deprecation messages for an easy upgrade.

closes #23 
