### PR TITLE
feat: derive baseUrl from `GITHUB_API_URL` when available

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -8,5 +8,10 @@ import { VERSION } from "./version";
 
 export const Octokit = Core.plugin(paginateRest, restEndpointMethods).defaults({
   authStrategy: createActionAuth,
+  baseUrl: getApiBaseUrl(),
   userAgent: `octokit-action.js/${VERSION}`,
 });
+
+function getApiBaseUrl(): string {
+  return process.env["GITHUB_API_URL"] || "https://api.github.com";
+}

--- a/test/smoke.test.ts
+++ b/test/smoke.test.ts
@@ -7,6 +7,7 @@ describe("Smoke test", () => {
     delete process.env.GITHUB_TOKEN;
     delete process.env.INPUT_GITHUB_TOKEN;
     delete process.env.GITHUB_ACTION;
+    delete process.env.GITHUB_API_URL;
   });
 
   it("happy path with GITHUB_TOKEN", () => {
@@ -20,6 +21,15 @@ describe("Smoke test", () => {
   it("happy path with INPUT_GITHUB_TOKEN", () => {
     process.env.INPUT_GITHUB_TOKEN = "secret123";
     process.env.GITHUB_ACTION = "test";
+
+    expect(Octokit).toBeInstanceOf(Function);
+    expect(() => new Octokit()).not.toThrow();
+  });
+
+  it("happy path with GITHUB_API_URL", () => {
+    process.env.GITHUB_TOKEN = "secret123";
+    process.env.GITHUB_ACTION = "test";
+    process.env.GITHUB_API_URL = "https://10.1.1.1/api/v3";
 
     expect(Octokit).toBeInstanceOf(Function);
     expect(() => new Octokit()).not.toThrow();


### PR DESCRIPTION
This change sets GHES base urls, from the `GITHUB_API_URL` environment variable.

For prior art: https://github.com/actions/toolkit/blob/1cc56db0ff126f4d65aeb83798852e02a2c180c3/packages/github/src/internal/utils.ts#L24