### PR TITLE
fix(proxy): init HttpsProxyAgent if a proxy should be used

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,7 @@ const DEFAULTS = {
   userAgent: `octokit-action.js/${VERSION}`,
 };
 
-const getProxyAgent = () => {
+function getProxyAgent() {
   const httpProxy = process.env["HTTP_PROXY"] || process.env["http_proxy"];
   if (httpProxy) {
     return new HttpsProxyAgent(httpProxy);
@@ -26,7 +26,7 @@ const getProxyAgent = () => {
   }
 
   return undefined;
-};
+}
 
 export const Octokit = Core.plugin(
   paginateRest,

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,20 @@ const DEFAULTS = {
   userAgent: `octokit-action.js/${VERSION}`,
 };
 
+const getProxyAgent = () => {
+  const httpProxy = process.env["HTTP_PROXY"] || process.env["http_proxy"];
+  if (httpProxy) {
+    return new HttpsProxyAgent(httpProxy);
+  }
+
+  const httpsProxy = process.env["HTTPS_PROXY"] || process.env["https_proxy"];
+  if (httpsProxy) {
+    return new HttpsProxyAgent(httpsProxy);
+  }
+
+  return undefined;
+};
+
 export const Octokit = Core.plugin(
   paginateRest,
   legacyRestEndpointMethods
@@ -22,7 +36,7 @@ export const Octokit = Core.plugin(
     ...DEFAULTS,
     ...options,
     request: {
-      agent: new HttpsProxyAgent(),
+      agent: getProxyAgent(),
       ...options.request,
     },
   };

--- a/test/smoke.test.ts
+++ b/test/smoke.test.ts
@@ -178,7 +178,7 @@ describe("Smoke test", () => {
     expect(data).toStrictEqual({ ok: true });
   });
 
-  it.each(["HTTPS_PROXY", "https_proxy"])(
+  it.each(["HTTPS_PROXY", "https_proxy", "HTTP_PROXY", "http_proxy"])(
     "Uses https-proxy-agent with %s env var",
     async (https_proxy_env) => {
       process.env.GITHUB_TOKEN = "secret123";


### PR DESCRIPTION
The proxy will throw if it's called without a valid proxy configured.

This was an oversight in #425.

This change adds the same behaviour as seen in other projects.