### PR TITLE
ci: rename `test` job to `test_matrix`, and add new `test` job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ name: Test
       - opened
       - synchronize
 jobs:
-  test:
+  test_matrix:
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -29,3 +29,13 @@ jobs:
         run: npm test
       - name: Test TypeScript
         run: npm run test:typescript
+  test:
+    runs-on: ubuntu-latest
+    needs: test_matrix
+    steps:
+      - run: exit 1
+        if: ${{ needs.test_matrix.result != 'success' }}
+      - uses: actions/checkout@v3
+      - run: npm ci
+      - run: npm run lint
+    if: ${{ always() }}


### PR DESCRIPTION
In order to not require tests to pass with specific versions of Node

<!-- Please refer to our contributing docs for any questions on submitting a pull request -->


<!-- Issues are required for both bug fixes and features. -->
Resolves #ISSUE_NUMBER

----

## Behavior

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* The Branch Protection rules would require that tests pass on certain versions of NodeJs, as there was no workflow job that required all Node versions tested

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* Brings the workflow in line with other Octokit repos
* Makes it so the Branch Protection rules don't need to require certain versions of Node


### Other information
<!-- Any other information that is important to this PR  -->

*

----

## Additional info

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Added the appropriate label for the given change

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/main/community/breaking_changes.md) to help!

- [ ] Yes (Please add the `Type: Breaking change` label)
- [x] No

If `Yes`, what's the impact:

* N/A


### Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please add the corresponding label for change this PR introduces:
- Dependencies/code cleanup: `Type: Maintenance`

----

