### PR TITLE
test(refactor): use 'toEqual' instead of 'toStrictEqual' for Responses

### DIFF
--- a/test/smoke.test.ts
+++ b/test/smoke.test.ts
@@ -230,8 +230,7 @@ describe("Smoke test", () => {
       title: "My test issue",
     });
 
-    // TODO: need a follow up issue to clean this up
-    expect(JSON.stringify(data)).toStrictEqual(JSON.stringify({ ok: true }));
+    expect(data).toEqual({ ok: true });
   });
 
   it.each(["HTTPS_PROXY", "https_proxy", "HTTP_PROXY", "http_proxy"])(


### PR DESCRIPTION
<!-- Issues are required for both bug fixes and features. -->
Resolves #515

----

## Behavior

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->
Test assertions of Responses from `fetch-mock` are done with `jest.toStrictEqual` with `JSON.stringify`

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->
Test assertions of Responses from `fetch-mock` are done with `jest.toEqual`


### Other information
<!-- Any other information that is important to this PR  -->
More context in https://github.com/octokit/core.js/issues/588

----

## Additional info

### Pull request checklist
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Added the appropriate label for the given change

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/main/community/breaking_changes.md) to help!

- [ ] Yes (Please add the `Type: Breaking change` label)
- [x] No

If `Yes`, what's the impact:

* N/A


### Pull request type
`Type: Maintenance`

----

